### PR TITLE
Fix Review Notifications: Missing Reviewee Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1434,6 +1434,45 @@ The ride object that the user is trying to delete (The ride object's owner has t
 | date                 | Date    | Yes      |                                             |
 | additionalProperties | Mixed   |          | fields specific to the type of notification |
 
+---
+
+### Leave a review notifications 
+These notifications are automatically sent to the driver and all of his passengers 12 hours after the ride begins. 
+
+The "Leave a review" notification contains the following additionalProperties: `rideId` and `usersToReview`. 
+- The `usersToReview` property contains an array of users that can be reviewed for the recipient of the notification. 
+
+- For example, a driver who rode with two passengers, user2 and user3, would receive the following notification. 
+``` 
+{
+    "_id" : ObjectId("5e98c4f1d1f2f342c4e30c94"),
+    "viewed" : false,
+    "date" : ISODate("2020-04-16T20:49:53.010Z"),
+    "username" : "user1",
+    "msg" : "Leave a review for your passengers, user2 and user3.",
+    "redirectPath" : "/driver/my-drives",
+    "__v" : 0,
+    "additionalProperties" : {
+        "rideId" : ObjectId("5e98c4bdd1f2f342c4e30c93"),
+        "usersToReview" : [ 
+            {
+                "username" : "user2",
+                "firstName" : "user2",
+                "picUrl" : "https://bruinpool-bucket-alpha.s3.us-east-2.amazonaws.com/defaultProfilePic/BruinPoolLogo_pink.png",
+                "picType" : "png"
+            }, 
+            {
+                "username" : "user3",
+                "firstName" : "user3",
+                "picUrl" : "https://bruinpool-bucket-alpha.s3.us-east-2.amazonaws.com/defaultProfilePic/BruinPoolLogo_purple.png",
+                "picType" : "png"
+            }
+        ]
+    }
+}
+```
+---
+
 ### API Endpoints
 
 | url                      | HTTP Method | description                                                         |

--- a/README.md
+++ b/README.md
@@ -1438,6 +1438,7 @@ The ride object that the user is trying to delete (The ride object's owner has t
 
 ### Leave a review notifications 
 These notifications are automatically sent to the driver and all of his passengers 12 hours after the ride begins. 
+When a user clicks on this notification, instead of being redirected to a page, a form appears for them to fill out.
 
 The "Leave a review" notification contains the following additionalProperties: `rideId` and `usersToReview`. 
 - The `usersToReview` property contains an array of users that can be reviewed for the recipient of the notification. 
@@ -1450,7 +1451,6 @@ The "Leave a review" notification contains the following additionalProperties: `
     "date" : ISODate("2020-04-16T20:49:53.010Z"),
     "username" : "user1",
     "msg" : "Leave a review for your passengers, user2 and user3.",
-    "redirectPath" : "/driver/my-drives",
     "__v" : 0,
     "additionalProperties" : {
         "rideId" : ObjectId("5e98c4bdd1f2f342c4e30c93"),
@@ -1470,6 +1470,7 @@ The "Leave a review" notification contains the following additionalProperties: `
         ]
     }
 }
+
 ```
 ---
 

--- a/README.md
+++ b/README.md
@@ -1426,18 +1426,20 @@ The ride object that the user is trying to delete (The ride object's owner has t
 
 | column               | type    | required | description                                 |
 | -------------------- | ------- | -------- | ------------------------------------------- |
-| username             | String  | Yes      |                                             |
-| email                | String  | Yes      |                                             |
-| msg                  | String  | Yes      |                                             |
+| username             | String  | Yes      | user receiving message                      |
+| msg                  | String  | Yes      | message to be displayed                     |
+| redirectPath         | String  |          | path to redirect when clicked               |
 | viewed               | Boolean | Yes      |                                             |
+| viewedAt             | Date    | Yes      |                                             |
+| date                 | Date    | Yes      |                                             |
 | additionalProperties | Mixed   |          | fields specific to the type of notification |
 
 ### API Endpoints
 
 | url                      | HTTP Method | description                                                         |
 | ------------------------ | ----------- | ------------------------------------------------------------------- |
-| /notis/noti   | GET         | [Get user's notifications](#get-user's-notifications)         |
-| /notis/view  | PUT         | [View the notification](#view-the-notification)       |
+| /notis/noti  | GET       | [Get user's notifications](#get-user's-notifications)                             |
+| /notis/view  | PUT       | [View the notification](#view-the-notification)                                   |
 
 ---
 

--- a/src/tasks/scheduledTasks.js
+++ b/src/tasks/scheduledTasks.js
@@ -30,33 +30,43 @@ const createNotiToLeaveReviewTask = (rideId) => {
     if (await isCompletedRide(rideDetails)) {
       const driverUsername = rideDetails.ownerUsername
       // Query for a list of passenger names to create driver notification 
-      let passengerFirstNames = []
+      let passengerInfo = []
       for (let i = 0; i < rideDetails.passengers.length; i++) {
         const passengerUsername = rideDetails.passengers[i]
         const passenger = await User.findOne({username: passengerUsername})
-        passengerFirstNames.push(passenger.firstName)                              
+        const {username, firstName, picUrl, picType} = passenger; 
+        passengerInfo.push({username, firstName, picUrl, picType})                              
       }
 
       // Send a notification to the driver to review their passengers 
-      const msg = await formatPassengerReviewMessage(passengerFirstNames)
-      await Noti.create({
+      const msg = await formatPassengerReviewMessage(passengerInfo.map(passenger => passenger.firstName))
+      const notiToDriver = await Noti.create({
         username: driverUsername, 
         msg, 
         date: new Date(),
         redirectPath: process.env.MY_DRIVES_PATH
       })
+      // Update schema-less property: additionalProperties to contain rideId and usersToReview
+      notiToDriver.additionalProperties = {rideId, usersToReview: passengerInfo};
+      notiToDriver.markModified("additionalProperties");
+      await notiToDriver.save();
 
       // Passengers each receive a notification to review driver
-      const driverName = (await User.findOne({username: driverUsername})).firstName 
-
+      const driver = await User.findOne({username: driverUsername}).lean()
+      const {username, firstName, picUrl, picType} = driver; 
+      const driverInfo = {username, firstName, picUrl, picType} 
       for (let i = 0; i < rideDetails.passengers.length; i++) {
         const passengerUsername = rideDetails.passengers[i]
-        await Noti.create({
+        const notiToPassenger = await Noti.create({
           username: passengerUsername, 
-          msg: `Leave a review for your driver, ${driverName}.`, 
+          msg: `Leave a review for your driver, ${driverInfo.firstName}.`, 
           date: new Date(),
           redirectPath: process.env.MY_RIDES_PATH
         })
+        // Update schema-less property: additionalProperties to contain rideId and driverInfo
+        notiToPassenger.additionalProperties = {rideId, usersToReview: [driverInfo]};
+        notiToPassenger.markModified("additionalProperties");
+        await notiToPassenger.save();
 
         // Schedule the last day passengers and drivers have to leave reviews 
         scheduler.scheduleTaskHoursAfterDate(`expireAbilityToLeaveReviewTask.${rideId}.${driverUsername}.${passengerUsername}`, 

--- a/src/tasks/scheduledTasks.js
+++ b/src/tasks/scheduledTasks.js
@@ -44,7 +44,6 @@ const createNotiToLeaveReviewTask = (rideId) => {
         username: driverUsername, 
         msg, 
         date: new Date(),
-        redirectPath: process.env.MY_DRIVES_PATH
       })
       // Update schema-less property: additionalProperties to contain rideId and usersToReview
       notiToDriver.additionalProperties = {rideId, usersToReview: passengerInfo};
@@ -61,7 +60,6 @@ const createNotiToLeaveReviewTask = (rideId) => {
           username: passengerUsername, 
           msg: `Leave a review for your driver, ${driverInfo.firstName}.`, 
           date: new Date(),
-          redirectPath: process.env.MY_RIDES_PATH
         })
         // Update schema-less property: additionalProperties to contain rideId and driverInfo
         notiToPassenger.additionalProperties = {rideId, usersToReview: [driverInfo]};

--- a/src/tasks/scheduler.js
+++ b/src/tasks/scheduler.js
@@ -7,6 +7,14 @@ const scheduleTaskHoursAfterDate = (uniqueTaskName, task, date, hours) => {
     schedule.scheduleJob(uniqueTaskName, scheduledDate, task) 
 }
 
+
+// Schedule a task to run once, X hours after a certain date
+const scheduleTaskMinutesAfterDate = (uniqueTaskName, task, date, minutes) => {
+    var scheduledDate = new Date(date)
+    scheduledDate.setMinutes(scheduledDate.getMinutes() + minutes)      
+    schedule.scheduleJob(uniqueTaskName, scheduledDate, task) 
+}
+
 const cancelTask = (taskName) => {
     return new Promise((resolve, reject) => {
         const task = schedule.scheduledJobs[taskName]
@@ -27,6 +35,7 @@ const cancelTasksAssociatedWithRide = (rideId) => {
 
 module.exports = {
     scheduleTaskHoursAfterDate,
+    scheduleTaskMinutesAfterDate,
     cancelTask, 
     cancelTasksAssociatedWithRide
 }

--- a/tests/tasks/scheduledTasks.test.js
+++ b/tests/tasks/scheduledTasks.test.js
@@ -56,23 +56,50 @@ describe("Testing leave a review notification", () => {
         await Review.deleteMany({})
     }) 
     test("Testing whether drivers and passengers receive proper notifications to leave a review", async () => {
-        let driver = await User.create({firstName: 'Sarah', username: 'driverUsername'})
-        let passenger1 = await User.create({firstName: 'John', username: 'passenger1'})
-        let passenger2 = await User.create({firstName: 'Aiden', username: 'passenger2'})
+        let driver = await User.create({firstName: 'Sarah', username: 'driverUsername', picUrl: 'driver_pic.png', picType: 'png'})
+        let passenger1 = await User.create({firstName: 'John', username: 'passenger1', picUrl: 'passenger1_pic.png', picType: 'png'})
+        let passenger2 = await User.create({firstName: 'Aiden', username: 'passenger2', picUrl: 'passenger2_pic.png', picType: 'png'})
         const ride = await Ride.create({ownerUsername: "driverUsername", passengers: ['passenger1', 'passenger2'], seats: 0})
         await scheduledTasks.createNotiToLeaveReviewTask(ride._id)()
 
-        expect(await Noti.findOne({username: ride.ownerUsername})).toEqual(expect.objectContaining({
-            username: driver.username, msg: "Leave a review for your passengers, John and Aiden.", redirectPath: process.env.MY_DRIVES_PATH
+        const driverNoti = await Noti.findOne({username: ride.ownerUsername})
+        expect(driverNoti).toEqual(expect.objectContaining({
+            username: driver.username, msg: "Leave a review for your passengers, John and Aiden.", redirectPath: process.env.MY_DRIVES_PATH 
         }))
-
-        expect(await Noti.findOne({username: passenger1.username})).toEqual(expect.objectContaining({
+        // Check additional properties in the driver notification 
+        expect(driverNoti.additionalProperties.rideId.toString()).toBe(ride._id.toString())
+        expect(driverNoti.additionalProperties.usersToReview).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                username: passenger1.username, firstName: passenger1.firstName, picUrl: passenger1.picUrl, picType: passenger1.picType
+            }),
+            expect.objectContaining({
+                username: passenger2.username, firstName: passenger2.firstName, picUrl: passenger2.picUrl, picType: passenger2.picType
+            })
+        ]))
+        
+        const passenger1Noti = await Noti.findOne({username: passenger1.username})
+        expect(passenger1Noti).toEqual(expect.objectContaining({
             username: passenger1.username, msg: "Leave a review for your driver, Sarah.", redirectPath: process.env.MY_RIDES_PATH
         }))
+        // Check additional properties in passenger one's notification 
+        expect(passenger1Noti.additionalProperties.rideId.toString()).toBe(ride._id.toString())
+        expect(passenger1Noti.additionalProperties.usersToReview).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                username: driver.username, firstName: driver.firstName, picUrl: driver.picUrl, picType: driver.picType
+            })
+        ]))
 
-        expect(await Noti.findOne({username: passenger2.username})).toEqual(expect.objectContaining({
+        const passenger2Noti = await Noti.findOne({username: passenger2.username})
+        expect(passenger2Noti).toEqual(expect.objectContaining({
             username: passenger2.username, msg: "Leave a review for your driver, Sarah.", redirectPath: process.env.MY_RIDES_PATH
         }))
+        // Check additional properties in passenger one's notification 
+        expect(passenger2Noti.additionalProperties.rideId.toString()).toBe(ride._id.toString())
+        expect(passenger2Noti.additionalProperties.usersToReview).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                username: driver.username, firstName: driver.firstName, picUrl: driver.picUrl, picType: driver.picType
+            })
+        ]))
     })
 
     test("Testing whether an expiry task is created for every review that can be sent out", async () => {


### PR DESCRIPTION
**From the documentation:** 

These notifications are automatically sent to the driver and all of his passengers 12 hours after the ride begins. 
When a user clicks on this notification, instead of being redirected to a page, a form appears for them to fill out.

The "Leave a review" notification contains the following additionalProperties: `rideId` and `usersToReview`. 
- The `usersToReview` property contains an array of users that can be reviewed for the recipient of the notification. 

- For example, a driver who rode with two passengers, user2 and user3, would receive the following notification. 
``` 
{
    "_id" : ObjectId("5e98c4f1d1f2f342c4e30c94"),
    "viewed" : false,
    "date" : ISODate("2020-04-16T20:49:53.010Z"),
    "username" : "user1",
    "msg" : "Leave a review for your passengers, user2 and user3.",
    "__v" : 0,
    "additionalProperties" : {
        "rideId" : ObjectId("5e98c4bdd1f2f342c4e30c93"),
        "usersToReview" : [ 
            {
                "username" : "user2",
                "firstName" : "user2",
                "picUrl" : "https://bruinpool-bucket-alpha.s3.us-east-2.amazonaws.com/defaultProfilePic/BruinPoolLogo_pink.png",
                "picType" : "png"
            }, 
            {
                "username" : "user3",
                "firstName" : "user3",
                "picUrl" : "https://bruinpool-bucket-alpha.s3.us-east-2.amazonaws.com/defaultProfilePic/BruinPoolLogo_purple.png",
                "picType" : "png"
            }
        ]
    }
}